### PR TITLE
base_url display for kirka.io is missing a second slash.

### DIFF
--- a/src/assets/html/menu.html
+++ b/src/assets/html/menu.html
@@ -1079,7 +1079,7 @@
         <div class="option">
           <span>Proxy URL</span>
           <select id="base_url" data-setting="base_url">
-            <option value="https://kirka.io/">https:/kirka.io/</option>
+            <option value="https://kirka.io/">https://kirka.io/</option>
             <option value="https://cloudyfrogs.com/">
               https://cloudyfrogs.com/
             </option>


### PR DESCRIPTION
No functional change, just a visual change. Also you can remove the https:// and the / at the end from the visual text.

A) https:// url /
B) url