### PR TITLE
Update swapper.js

### DIFF
--- a/src/addons/swapper.js
+++ b/src/addons/swapper.js
@@ -5,7 +5,7 @@ const url = require("url");
 
 const initResourceSwapper = () => {
   protocol.registerFileProtocol("juiceclient", (request, callback) =>
-    callback({ path: request.url.replace("juiceclient://", "") })
+    callback({ path: request.url.replace("juiceclient://", "") }),
   );
   protocol.registerFileProtocol("file", (request, callback) => {
     callback(decodeURIComponent(request.url.replace("file:///", "")));
@@ -14,10 +14,14 @@ const initResourceSwapper = () => {
   const SWAP_FOLDER = path.join(
     app.getPath("documents"),
     "JuiceClient",
-    "swapper"
+    "swapper",
   );
   const assetsFolder = path.join(SWAP_FOLDER, "assets");
-  const folders = ["css", "media", "img", "glb"];
+  const folders = ["css", "media", "img", "glb", "js"];
+  let folder_regex_generator = "JuiceClient[\\\\/]swapper[\\\\/]assets[\\\\/](";
+  folder_regex_generator += folders.join("|");
+  folder_regex_generator += ")[\\\\/][^\\\\/]+\\.[^.]+$";
+  let folder_regex = new RegExp(folder_regex_generator, "");
 
   try {
     if (!fs.existsSync(assetsFolder))
@@ -50,10 +54,7 @@ const initResourceSwapper = () => {
       const filePath = path.join(dir, file);
       if (fs.statSync(filePath).isDirectory()) allFilesSync(filePath);
       else {
-        const useAssets =
-          /JuiceClient[\\/]swapper[\\/]assets[\\/](css|media|img|glb)[\\/][^\\/]+\.[^.]+$/.test(
-            filePath
-          );
+        const useAssets = folder_regex.test(filePath);
         if (!useAssets) return;
 
         proxyUrls.forEach((proxy) => {
@@ -83,7 +84,7 @@ const initResourceSwapper = () => {
           (swap.files[details.url.replace(/https|http|(\?.*)|(#.*)/gi, "")] ||
             details.url);
         callback({ cancel: false, redirectURL: redirect });
-      }
+      },
     );
   }
 };

--- a/src/util/shortcuts.js
+++ b/src/util/shortcuts.js
@@ -30,6 +30,8 @@ const registerShortcuts = (window) => {
   register("F11", () => window.setFullScreen(!window.isFullScreen()));
   register("F12", () => window.webContents.openDevTools());
   register("Ctrl+Shift+I", () => window.webContents.openDevTools());
+  register("Ctrl+Shift+C", () => window.webContents.openDevTools());
+  register("Ctrl+Shift+J", () => window.webContents.openDevTools());
   register("Alt+F4", () => app.quit());
 };
 


### PR DESCRIPTION
Made the swapper to a more dynamically regex generation
instead on relying on folders & the regex to support all types. 
It only relies on the folders array

Check to see if it didn't changed functunality:
```js
let folders = ["css", "media", "img", "glb", "js"];
let folder_regex_generator = "JuiceClient[\\\\/]swapper[\\\\/]assets[\\\\/](";
folder_regex_generator += folders.join("|");
folder_regex_generator += ")[\\\\/][^\\\\/]+\\.[^.]+$";
let folder_regex = new RegExp(folder_regex_generator, "");

folder_regex.toString() ==
  /JuiceClient[\\/]swapper[\\/]assets[\\/](css|media|img|glb|js)[\\/][^\\/]+\.[^.]+$/.toString();
```