### PR TITLE
formatted two scripts; replaced require screen to the start

### DIFF
--- a/src/preload/splash.js
+++ b/src/preload/splash.js
@@ -1,33 +1,24 @@
-const { ipcRenderer } = require("electron");
-const version = require("../../package.json").version;
+const { ipcRenderer } = require("electron")
+const version = require("../../package.json").version
 
 document.addEventListener("DOMContentLoaded", () => {
-  const versionElement = document.querySelector(".ver");
-  const statusElement = document.querySelector(".status");
+  const versionElement = document.querySelector(".ver")
+  const statusElement = document.querySelector(".status")
 
-  versionElement.textContent = `v${version}`;
+  versionElement.textContent = `v${version}`
 
-  const updateStatus = (status) => {
-    statusElement.textContent = status;
-  };
+  const updateStatus = status => statusElement.textContent = status
 
-  ipcRenderer.send("check-for-updates");
-  updateStatus("Checking for updates...");
+  ipcRenderer.send("check-for-updates")
+  updateStatus("Checking for updates...")
 
-  ipcRenderer.on("update-available", () => {
-    updateStatus("Update available! Downloading...");
-  });
-
-  ipcRenderer.on("update-not-available", () => {
-    updateStatus("No updates available. Launching...");
-  });
+  ipcRenderer.on("update-available", () => updateStatus("Update available! Downloading..."))
+  ipcRenderer.on("update-not-available", () => updateStatus("No updates available. Launching..."))
 
   ipcRenderer.on("update-downloaded", () => {
-    updateStatus("Update downloaded! Installing...");
-    ipcRenderer.send("quit-and-install");
-  });
+    updateStatus("Update downloaded! Installing...")
+    ipcRenderer.send("quit-and-install")
+  })
 
-  ipcRenderer.on("download-progress", (e, progress) => {
-    updateStatus(`Downloading update: ${Math.round(progress.percent)}%`);
-  });
-});
+  ipcRenderer.on("download-progress", (_, progress) => updateStatus(`Downloading update: ${Math.round(progress.percent)}%`))
+})

--- a/src/util/shortcuts.js
+++ b/src/util/shortcuts.js
@@ -1,38 +1,28 @@
-const { app, clipboard } = require("electron");
-const Store = require("electron-store");
-const shortcut = require("electron-localshortcut");
+const { app, clipboard, screen } = require("electron")
+const shortcut = require("electron-localshortcut")
+const Store = require("electron-store")
+const store = new Store()
 
-const store = new Store();
-
-const registerShortcuts = (window) => {
-  const register = (key, action) => shortcut.register(window, key, action);
-  register("Escape", () =>
-    window.webContents.executeJavaScript("document.exitPointerLock()")
-  );
+const registerShortcuts = window => {
+  const register = (key, action) => shortcut.register(window, key, action)
+  register("Escape", () => window.webContents.executeJavaScript("document.exitPointerLock()"))
   register("F2", () => {
-    const { screen } = require("electron");
-    const { x, y, width, height } = screen.getPrimaryDisplay().bounds;
-    window.capturePage({ x, y, width, height }).then((image) => {
-      clipboard.writeImage(image);
-      const message = "Screenshot copied to clipboard";
-      const icon = image.toDataURL();
-      const data = { message, icon };
-      window.webContents.send("notification", data);
-    });
-  });
-  register("F4", () => {
-    const settings = store.get("settings");
-    window.loadURL(settings.base_url);
-  });
-  register("F5", () => window.reload());
-  register("F6", () => window.loadURL(clipboard.readText()));
-  register("F7", () => clipboard.writeText(window.webContents.getURL()));
-  register("F11", () => window.setFullScreen(!window.isFullScreen()));
-  register("F12", () => window.webContents.toggleDevTools());
-  register("Ctrl+Shift+I", () => window.webContents.toggleDevTools());
-  register("Ctrl+Shift+C", () => window.webContents.toggleDevTools());
-  register("Ctrl+Shift+J", () => window.webContents.toggleDevTools());
-  register("Alt+F4", () => app.quit());
-};
+    const { x, y, width, height } = screen.getPrimaryDisplay().bounds
+    window.capturePage({ x, y, width, height }).then(image => {
+      clipboard.writeImage(image)
+      window.webContents.send("notification", { message: "Screenshot copied to clipboard", icon: image.toDataURL() })
+    })
+  })
+  register("F4", () => window.loadURL(store.get("settings").base_url))
+  register("F5", () => window.reload())
+  register("F6", () => window.loadURL(clipboard.readText()))
+  register("F7", () => clipboard.writeText(window.webContents.getURL()))
+  register("F11", () => window.setFullScreen(!window.isFullScreen()))
+  register("F12", () => window.webContents.toggleDevTools())
+  register("Ctrl+Shift+I", () => window.webContents.toggleDevTools())
+  register("Ctrl+Shift+C", () => window.webContents.toggleDevTools())
+  register("Ctrl+Shift+J", () => window.webContents.toggleDevTools())
+  register("Alt+F4", () => app.quit())
+}
 
-module.exports = { registerShortcuts };
+module.exports = { registerShortcuts }


### PR DESCRIPTION
formatted two scripts
replaced const { screen } = require("electron") to the start of shortcuts.js because of performance. you don't need to require("electron") every time you press F2