### PR TITLE
Read desc (revert PR #22)

### DIFF
--- a/src/util/shortcuts.js
+++ b/src/util/shortcuts.js
@@ -21,15 +21,12 @@ const registerShortcuts = (window) => {
   });
   register("F4", () => {
     window.loadURL(store.get("settings").base_url);
-    initResourceSwapper();
   });
   register("F5", () => {
     window.reload();
-    initResourceSwapper();
   });
   register("F6", () => {
     window.loadURL(clipboard.readText());
-    initResourceSwapper();
   });
   register("F7", () => clipboard.writeText(window.webContents.getURL()));
   register("F11", () => window.setFullScreen(!window.isFullScreen()));


### PR DESCRIPTION
Running the extensive and FS checking function initResourceSwapper(); every time you either load a url or reload the page increased load times. Unnecessary addition causes more issues then not. Either make a keybind/button to reload client settings or continue as it was previously working.