### PR TITLE
Resizable splash window

### DIFF
--- a/src/windows/splash.js
+++ b/src/windows/splash.js
@@ -22,6 +22,7 @@ const createWindow = () => {
     frame: false,
     transparent: true,
     resizable: false,
+    fullscreenable: false,
     webPreferences: {
       preload: path.join(__dirname, "../preload/splash.js"),
     },


### PR DESCRIPTION
When pressing F11 button (fullscreen mode), splash window behaves in a strange way. The `fullscreenable` key will prevent this behavior.